### PR TITLE
feat: add GitHub Actions workflows and package improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - main
+            - dev
+
+jobs:
+    ci:
+        uses: builtnorth/basecamp-dev/.github/.github/workflows/npm-package-ci.yml@dev
+        with:
+            package-name: "ui-kit"
+            # Skip tests, lint, and build since this is a pure SCSS package
+            run-tests: false
+            run-lint: false
+            run-build: false
+            use-workspace: true
+        secrets:
+            POLARIS_PLUGIN_GITHUB_TOKEN: ${{ secrets.POLARIS_PLUGIN_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+    push:
+        tags:
+            - "v*"
+    workflow_dispatch:
+        inputs:
+            version:
+                description: "Version to release (e.g., 1.0.0)"
+                required: true
+                type: string
+            prerelease:
+                description: "Is this a pre-release?"
+                required: false
+                type: boolean
+                default: false
+
+jobs:
+    release:
+        uses: builtnorth/basecamp-dev/.github/.github/workflows/npm-package-release.yml@dev
+        with:
+            version: ${{ inputs.version }}
+            prerelease: ${{ inputs.prerelease }}
+            package-name: "ui-kit"
+            node-version: "22"
+            publish-to-npm: false
+            publish-to-github: true
+            use-workspace: false # SCSS package doesn't need workspace dependencies
+        secrets:
+            POLARIS_PLUGIN_GITHUB_TOKEN: ${{ secrets.POLARIS_PLUGIN_GITHUB_TOKEN }}
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,13 @@
-src
+# Development files
+.github/
+.gitignore
+node_modules/
+
+# Build configuration (not needed since we publish source SCSS)
 rollup.config.js
-.babelrc
-node_modules
-dist
 rollup.config.mjs
+.babelrc
 babel.config.json
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# @builtnorth/ui-kit
+
+NPM package for very minimal global and common CSS and JS utilities.
+
+## Installation
+
+```bash
+npm install @builtnorth/ui-kit
+```
+
+## Usage
+
+This package exports SCSS files that can be imported into your project.
+
+### Import Everything
+
+```scss
+@import "@builtnorth/ui-kit";
+```
+
+### Import Essential Styles Only
+
+```scss
+@import "@builtnorth/ui-kit/essential-styles";
+```
+
+### Import Specific Modules
+
+```scss
+// Base styles
+@import "@builtnorth/ui-kit/base";
+@import "@builtnorth/ui-kit/base/utilities";
+@import "@builtnorth/ui-kit/base/reset";
+@import "@builtnorth/ui-kit/base/accessibility";
+@import "@builtnorth/ui-kit/base/images";
+@import "@builtnorth/ui-kit/base/colors";
+
+// Components
+@import "@builtnorth/ui-kit/components";
+@import "@builtnorth/ui-kit/components/buttons";
+@import "@builtnorth/ui-kit/components/slider";
+
+// Forms
+@import "@builtnorth/ui-kit/forms";
+@import "@builtnorth/ui-kit/forms/label";
+@import "@builtnorth/ui-kit/forms/fieldset";
+@import "@builtnorth/ui-kit/forms/select";
+@import "@builtnorth/ui-kit/forms/checkbox";
+@import "@builtnorth/ui-kit/forms/text";
+
+// Helpers
+@import "@builtnorth/ui-kit/helpers";
+@import "@builtnorth/ui-kit/helpers/mixins";
+@import "@builtnorth/ui-kit/helpers/functions";
+@import "@builtnorth/ui-kit/helpers/media-queries";
+
+// Layout
+@import "@builtnorth/ui-kit/layout";
+@import "@builtnorth/ui-kit/layout/grid";
+@import "@builtnorth/ui-kit/layout/columns";
+
+// Gutenberg
+@import "@builtnorth/ui-kit/gutenberg";
+@import "@builtnorth/ui-kit/gutenberg/quirks";
+@import "@builtnorth/ui-kit/gutenberg/placeholders";
+@import "@builtnorth/ui-kit/gutenberg/appenders";
+```
+
+## What's Included
+
+- **Base**: Reset, utilities, accessibility, images, and color utilities
+- **Components**: Buttons, sliders, pagination
+- **Forms**: Styled form elements (labels, fieldsets, selects, checkboxes, text inputs)
+- **Helpers**: Mixins, functions, and media query utilities
+- **Layout**: Grid and column systems
+- **Gutenberg**: WordPress block editor specific styles
+
+## License
+
+GPL-2.0-or-later
+
+## Author
+
+Built North

--- a/package.json
+++ b/package.json
@@ -3,16 +3,19 @@
 	"version": "1.0.0",
 	"description": "NPM package for very minimal global and common CSS and JS.",
 	"main": "index.js",
+	"scripts": {
+		"build": "mkdir -p build && cp -r src build/ && cp index.js build/ && cp README.md build/ 2>/dev/null || true"
+	},
 	"repository": {
 		"type": "git",
-		"url": "git+:https://github.com/builtnorth/wp-admin-dashboard.git"
+		"url": "git+https://github.com/builtnorth/ui-kit.git"
 	},
 	"author": "Built North",
 	"license": "GPL-2.0-or-later",
 	"bugs": {
-		"url": "https://github.com/builtnorth/wp-admin-dashboard.git/issues"
+		"url": "https://github.com/builtnorth/ui-kit/issues"
 	},
-	"homepage": "https://github.com/builtnorth/wp-admin-dashboard?tab=readme-ov-file#readme",
+	"homepage": "https://github.com/builtnorth/ui-kit#readme",
 	"exports": {
 		".": "./src/scss/style.scss",
 		"./essential-styles": "./src/scss/essential-styles.scss",


### PR DESCRIPTION
- Add CI workflow that uses reusable npm-package-ci.yml
- Add Release workflow for automated publishing to GitHub Packages
- Update package.json with build script and correct repository URLs
- Update .npmignore to properly include src/ directory for SCSS exports
- Add comprehensive README with installation and usage documentation

The workflows are configured for a pure SCSS package:
- CI skips tests, lint, and build steps
- Release publishes to GitHub Packages only
- Both workflows reference basecamp-dev reusable workflows

This brings ui-kit in line with other Built North npm packages and enables automated releases via git tags or manual workflow dispatch.