### PR TITLE
Enhance layout with image resizing and column modifiers

### DIFF
--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -11,36 +11,39 @@
 
 // Form Field Settings
 // ----------------------------------------------------------------------------
-$form-field-padding: var(--wp--custom--form-field-padding, 0.11rem) !default;
+$form-field-padding: var(--wp--custom--form--field-padding, 0.11rem) !default;
 $form-field-border-width: var(
-	--wp--custom--form-field-border-width,
+	--wp--custom--form--field-border-width,
 	1px
 ) !default;
 $form-field-border-color: var(
-	--wp--custom--form-field-border-color,
+	--wp--custom--form--field-border-color,
 	#8e8e8e
 ) !default;
 $form-field-border-radius: var(
-	--wp--custom--form-field-border-radius,
+	--wp--custom--form--field-border-radius,
 	0
 ) !default;
 $form-field-focus-color: var(
-	--wp--custom--form-field-focus-color,
+	--wp--custom--form--field-focus-color,
 	var(--wp--preset--color--primary)
 ) !default;
-$form-field-bg-color: var(--wp--custom--form-field-bg-color, #fff) !default;
-$form-field-text-color: var(--wp--custom--form-field-text-color, #000) !default;
+$form-field-bg-color: var(--wp--custom--form--field-bg-color, #fff) !default;
+$form-field-text-color: var(
+	--wp--custom--form--field-text-color,
+	#000
+) !default;
 
 // Form Choice Settings (checkbox/radio)
 // ----------------------------------------------------------------------------
-$form-choice-size: var(--wp--custom--form-choice-size, 1.125rem) !default;
-$form-choice-spacing: var(--wp--custom--form-choice-spacing, 0.25rem) !default;
+$form-choice-size: var(--wp--custom--form--choice-size, 1.125rem) !default;
+$form-choice-spacing: var(--wp--custom--form--choice-spacing, 0.25rem) !default;
 $form-choice-border-radius: var(
-	--wp--custom--form-choice-border-radius,
+	--wp--custom--form--choice-border-radius,
 	0.25rem
 ) !default;
 $form-choice-checked-color: var(
-	--wp--custom--form-choice-checked-color,
+	--wp--custom--form--choice-checked-color,
 	var(--wp--preset--color--primary)
 ) !default;
 

--- a/src/scss/base/_utilities.scss
+++ b/src/scss/base/_utilities.scss
@@ -65,13 +65,26 @@ Classes to quickly add utility styles to your components.
 		padding-right: 0;
 	}
 }
-// .alignright {
-//     float: right;
-// }
 
-// .alignleft {
-//     float: left;
-// }
+.aligncenter {
+	margin-left: auto !important;
+	margin-right: auto !important;
+	display: flex !important;
+	width: auto !important;
+	align-self: center;
+}
+.alignleft {
+	float: none !important;
+	display: flex !important;
+	align-self: flex-start;
+	width: auto !important;
+}
+.alignright {
+	float: none !important;
+	display: flex !important;
+	align-self: flex-end;
+	width: auto !important;
+}
 
 /* Image Styles
 ------------------------------------------------------------------*/

--- a/src/scss/gutenberg/_misc.scss
+++ b/src/scss/gutenberg/_misc.scss
@@ -36,14 +36,14 @@ Misc
 	}
 }
 
-/* Hide the drag handle for core/image blocks
+/* Hide the drag handle for core/image blocks - keeping this is the better option
 -----------------------------------------------------------------*/
-.wp-block-polaris-image-card,
-.wp-block-polaris-hero {
-	.wp-block-image .components-resizable-box__handle {
-		display: none !important;
-	}
-}
+// .wp-block-polaris-image-card,
+// .wp-block-polaris-hero {
+// 	.wp-block-image .components-resizable-box__handle {
+// 		display: none !important;
+// 	}
+// }
 
 /* Full width button */
 .components-button.is-full-width {

--- a/src/scss/gutenberg/_quirks.scss
+++ b/src/scss/gutenberg/_quirks.scss
@@ -9,7 +9,7 @@
 // }
 
 // Allow sticky to work with template parts
-.wp-block-template-part:not(header) {
+.wp-block-template-part:not(header, footer) {
 	display: contents;
 }
 

--- a/src/scss/layout/_columns.scss
+++ b/src/scss/layout/_columns.scss
@@ -39,6 +39,13 @@
 			width: auto;
 		}
 
+		/* Sizes to inner content; use with justify-content: space-between on the row */
+		&--shrink {
+			flex: 0 0 auto;
+			width: auto;
+			max-width: 100%;
+		}
+
 		@for $i from 1 through 12 {
 			&--span-#{$i} {
 				flex-basis: #{math.percentage(math.div($i, 12))};

--- a/src/scss/layout/_columns.scss
+++ b/src/scss/layout/_columns.scss
@@ -50,6 +50,11 @@
 		}
 	}
 
+	// Allow columns to wrap onto multiple rows
+	&.is-flex-wrap {
+		flex-wrap: wrap;
+	}
+
 	// Mobile Stacking - Override default mobile stacking
 	&.no-stack-on-mobile {
 		/* Container query override */


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the SCSS codebase, primarily focusing on standardizing custom property naming, enhancing utility and layout classes, and refining Gutenberg editor quirks. The most significant changes include the adoption of consistent double-dash naming for CSS custom properties, the addition of new alignment and layout utility classes, and updates to Gutenberg block styling for better compatibility and flexibility.

**SCSS Variable Naming Consistency:**

* Standardized all custom property names used in form field and choice settings to use double dashes (e.g., `--wp--custom--form--field-padding` instead of `--wp--custom--form-field-padding`) in `_config.scss`.

**Utility and Layout Enhancements:**

* Added new utility classes `.aligncenter`, `.alignleft`, and `.alignright` to `_utilities.scss` for improved alignment control using flexbox, replacing previously commented-out float-based classes.
* Introduced a `.wp-block-columns__column--shrink` modifier in `_columns.scss` to allow columns to size to their inner content, and added an `.is-flex-wrap` class to enable column wrapping. [[1]](diffhunk://#diff-74329377822794c9daa91788f4c74ca4f0a50b5e2daa3ab01f899f1e24d13ee7R42-R48) [[2]](diffhunk://#diff-74329377822794c9daa91788f4c74ca4f0a50b5e2daa3ab01f899f1e24d13ee7R60-R64)

**Gutenberg Editor Adjustments:**

* Updated the selector in `_quirks.scss` to allow sticky positioning for all template parts except `header` and `footer`, improving layout flexibility.
* Commented out the rule hiding the drag handle for image blocks in `_misc.scss`, making it easier to re-enable if needed.